### PR TITLE
Update shell.rs

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -26,15 +26,6 @@ pub enum ShellError {
     IoError(std::io::Error),
 }
 
-impl std::fmt::Display for ShellError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ApiError(msg) => write!(f, "API Error: {}", msg),
-            Self::ConfigError(msg) => write!(f, "Configuration Error: {}", msg),
-            Self::IoError(e) => write!(f, "IO Error: {}", e),
-        }
-    }
-}
 
 impl std::error::Error for ShellError {}
 


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
- Removed the implementation of the `std::fmt::Display` trait for the `ShellError` enum.
- This change simplifies the code by removing custom error formatting logic.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `src/shell.rs`: The `std::fmt::Display` trait implementation for the `ShellError` enum was removed. This implementation previously provided custom error messages for different variants of `ShellError`, including `ApiError`, `ConfigError`, and `IoError`. The removal of this implementation suggests that the default error formatting is now being used or that the formatting is handled elsewhere.
</details>
